### PR TITLE
Added version key to manifest

### DIFF
--- a/custom_components/greenely/manifest.json
+++ b/custom_components/greenely/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [],
+  "version": ""
 }


### PR DESCRIPTION
Home Assistant will soon require integrations to have a version key in their manifest files, otherwise the integrations will break. The log from Home Assistant is messaging about this.