### PR TITLE
Fixed incorrect example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ date_format: '%Y-%m-%d'
   columns:
     - name: date
       attr_as_list: data
-      modify: x.date
+      modify: x.localtime
       icon: mdi:calendar
     - name: kWh
       attr_as_list: data


### PR DESCRIPTION
Using x.date gives "undefined" as an output. The correct value to use is x.localtime.