### PR TITLE
Fix blocking httpx calls inside the event loop

### DIFF
--- a/custom_components/greenely/__init__.py
+++ b/custom_components/greenely/__init__.py
@@ -36,9 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: GreenelyConfigEntry) -> 
 
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
-    if api.check_auth():
+    if await hass.async_add_executor_job(api.check_auth):
         facilityId = (
-            api.get_facility_id()
+            await hass.async_add_executor_job(api.get_facility_id)
             if entry.data.get(GREENELY_FACILITY_ID, "") == ""
             else entry.data[GREENELY_FACILITY_ID]
         )

--- a/custom_components/greenely/config_flow.py
+++ b/custom_components/greenely/config_flow.py
@@ -48,17 +48,18 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 class Greenelyhub:
     """Class to authenticate with the host."""
 
-    def __init__(self, email: str, password: str):
+    def __init__(self, hass: HomeAssistant, email: str, password: str):
+        self.hass = hass
         self.email = email
         self.password = password
         self.api = GreenelyApi(self.email, self.password)
 
     async def authenticate(self) -> bool:
         """Test if we can authenticate with the host."""
-        return self.api.check_auth()
+        return await self.hass.async_add_executor_job(self.api.check_auth)
 
     async def get_facility_id(self) -> int:
-        return int(self.api.get_facility_id())
+        return int(await self.hass.async_add_executor_job(self.api.get_facility_id))
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
@@ -67,7 +68,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
 
-    hub = Greenelyhub(data[CONF_EMAIL], data[CONF_PASSWORD])
+    hub = Greenelyhub(hass, data[CONF_EMAIL], data[CONF_PASSWORD])
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/greenely/services.py
+++ b/custom_components/greenely/services.py
@@ -30,7 +30,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         password = call.data[CONF_PASSWORD]
 
         api = GreenelyApi(email, password)
-        if not api.check_auth():
+        if not await hass.async_add_executor_job(api.check_auth):
             await hass.services.async_call(
                 NOTIFY_DOMAIN,
                 "persistent_notification",
@@ -39,7 +39,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
 
         else:
-            facilityIds = api.get_facility_ids()
+            facilityIds = await hass.async_add_executor_job(api.get_facility_ids)
             _LOGGER.info("Facilities fetched successfully")
 
             facilityIdsOutput = []


### PR DESCRIPTION
Fixes #59
Fixes #66

## What

Three remaining call sites called sync `httpx.get()` / `httpx.post()` from within async contexts:

- `__init__.py: async_setup_entry` — `api.check_auth()` and `api.get_facility_id()`
- `config_flow.py: Greenelyhub.authenticate / .get_facility_id` (declared `async` but bodies were sync)
- `services.py: async_fetch_facilities` — `api.check_auth()` and `api.get_facility_ids()`

Each sync HTTPS request triggers `ssl.SSLContext.load_verify_locations` on first use, which Home Assistant now warns about:

> *Detected blocking call to load_verify_locations inside the event loop*

## How

Wrapped each call in `hass.async_add_executor_job(...)` so the blocking work runs on a thread. `Greenelyhub` now receives `hass` to use the executor.

The sync `update()` polling path in `sensor.py` is unaffected — those methods are already executed on an executor thread by Home Assistant's polling system, so they were never the source of the warnings.

## Testing

- [ ] Manually verified config flow still completes without warnings
- [ ] Sensors keep updating